### PR TITLE
Update 2017-09-29-use-rails-naming-conventions-for-dates-and-times.md

### DIFF
--- a/_posts/2017/2017-09-29-use-rails-naming-conventions-for-dates-and-times.md
+++ b/_posts/2017/2017-09-29-use-rails-naming-conventions-for-dates-and-times.md
@@ -10,14 +10,14 @@ image:
   source: 'https://unsplash.com/photos/PypjzKTUqLo'
 ---
 
-Rails includes default managed timestamps, `updated_at` and `created_at`, for ActiveRecord models.
+Rails includes the default managed timestamps `updated_at` and `created_at` for ActiveRecord models.
 
-However on many applications diving into a `schema.rb` or migration often reveals `something_date` as a field name on a model.
+However, on many applications, diving into a `schema.rb` or migration often reveals `something_date` as a field name on a model.
 
 
 ## Instead of…
 
-...including the word `date` and `time` in your database columns.
+...including the words `date` or `time` in your database columns:
 
 ```ruby
 class NaughtyMigration < ActiveRecord::Migration[5.1]
@@ -29,7 +29,7 @@ end
 
 ## Use…
 
-...the suffixes `at` for times and `on` for dates.
+...the suffix `at` for times and `on` for dates.
 
 ```ruby
 class AwesomeMigration < ActiveRecord::Migration[5.1]
@@ -41,10 +41,10 @@ end
 
 ## But why?
 
-Rails’ own timestamps give us a convention we can reuse and it’s a good idea to suffix times in the same way. A `due_on` field lets you know to expect a date and gives instant feedback to readers of your code about the expected data stored in the database.
+Including the word `time` or `date` in the variable name is redundant and adds to the visual noise of the code. You don’t say `first_name_string`, do you?
+
+Given Rails' conventions, something like a `due_on` field lets you know to expect a date. You give instant feedback to anyone reading your code about the expected data stored in the database.
 
 I _might_ allow myself the occasional `_until` if it makes the variable easier to read.
-
-Including the word `time` or `date` in the variable name is redundant and adds to the visual noise of the code. You don’t say `first_name_string`, do you?
 
 For me, the naming constraint also _makes me think harder_ about the right name.


### PR DESCRIPTION
> However, on many applications, diving into a `schema.rb` or migration often reveals `something_date` as a field name on a model.

This sentence isn't clear. Can you try and explain in a different way what you mean? Is this `something_date` coming from something the developer has done? And so what is the problem? Are you trying to say that we should be using the default managed timestamps instead of creating our own?

I like your examples!

 >Rails’ own timestamps give us a convention we can reuse and it’s a good idea to suffix times in the same way.

Deleted this because you still haven't got to the 'But why?' and that's what you said this section was. By this point, we know that this is a Rails convention and that you're telling us to suffix it in the same way. So tell us: why?