### PR TITLE
`\z` should be preferred over `\Z` to match end of string

### DIFF
--- a/_posts/2018/2018-06-10-beginning-and-end-of-string-in-regex.md
+++ b/_posts/2018/2018-06-10-beginning-and-end-of-string-in-regex.md
@@ -30,12 +30,12 @@ However, we should beware.
 
 ## Use…
 
-…`\A` and `\Z`.
+…`\A` and `\z`.
 
 ```ruby
 # A regular expression matching a
 # string of lowercase letters
-/\A[a-z]+\Z/
+/\A[a-z]+\z/
 ```
 
 


### PR DESCRIPTION
Hi Andy,

There is a mix of `\z` and `\Z` in last post. `\z` should be preferred as it matches only the end of the string, whereas `\Z` can also match if there is a final newline after it.

This pull request uses `\z` everywhere.

```ruby
> "word".match?(/\A[a-z]+\z/)
=> true
> "word".match?(/\A[a-z]+\Z/)
=> true
> "word\n".match?(/\A[a-z]+\z/)
=> false
> "word\n".match?(/\A[a-z]+\Z/)
=> true
> "word\n\n".match?(/\A[a-z]+\z/)
=> false
> "word\n\n".match?(/\A[a-z]+\Z/)
=> false
```