### PR TITLE
feat: Add animated lazy loading for images

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 ruby file: ".ruby-version"
 
 gem "jekyll"
+gem "nokogiri"
 gem "jekyll-compose", group: [:jekyll_plugins]
 gem "jekyll-redirect-from", group: [:jekyll_plugins]
 gem "jekyll-sitemap", group: [:jekyll_plugins]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,9 +62,14 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
+    mini_portile2 (2.8.9)
+    nokogiri (1.18.10)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (7.0.0)
+    racc (1.8.1)
     rake (13.3.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
@@ -90,6 +95,7 @@ DEPENDENCIES
   jekyll-redirect-from
   jekyll-sitemap
   jekyll-tailwind
+  nokogiri
   webrick
 
 RUBY VERSION

--- a/_includes/javascripts.html
+++ b/_includes/javascripts.html
@@ -1,2 +1,12 @@
 <script src="https://cdn.usefathom.com/script.js" data-site="HUFOLVIQ" defer></script>
 <script src="https://instant.page/5.1.0" type="module" integrity="sha384-by67kQnR+pyfy8yWP4kPO12fHKRLHZPfEsiSXR8u2IKcTdxD805MGUXBzVPnkLHw" defer></script>
+<script>
+document.querySelectorAll('img[loading="lazy"]').forEach(function(img) {
+  if (img.complete) {
+    img.classList.add('loaded');
+  } else {
+    img.addEventListener('load', function() { img.classList.add('loaded'); }, { once: true });
+    img.addEventListener('error', function() { img.classList.add('loaded'); }, { once: true });
+  }
+});
+</script>

--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -20,6 +20,7 @@ layout: default
             {{ image_url_root }}{{ page.image.base }}.jpg?width=2048 2048w
           "
           class="aspect-4/1 w-full sm:rounded sm:px-3"
+          data-no-lazy
         >
       </picture>
 

--- a/_plugins/lazy_images.rb
+++ b/_plugins/lazy_images.rb
@@ -1,0 +1,17 @@
+require "nokogiri"
+
+Jekyll::Hooks.register [:pages, :documents], :post_render do |doc|
+  next unless doc.output_ext == ".html"
+
+  parsed = Nokogiri::HTML::DocumentFragment.parse(doc.output)
+
+  parsed.css("img").each do |img|
+    next if img["loading"]
+    next if img["src"]&.match?(/\.svg($|\?)/i)
+    next if img["data-no-lazy"]
+
+    img["loading"] = "lazy"
+  end
+
+  doc.output = parsed.to_html
+end

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,3 +1,19 @@
+@media (scripting: enabled) {
+  img[loading="lazy"] {
+    opacity: 0;
+    transition: opacity 0.3s ease-in-out;
+  }
+
+  img[loading="lazy"].loaded {
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  img[loading="lazy"] {
+    transition: none;
+  }
+}
 
 .amp {
   font-family: Baskerville, Constantia, Palatino, "Palatino Linotype", "Times New Roman", Times, serif;


### PR DESCRIPTION
## Summary

Implements fade-in animation for lazy-loaded images using the technique from [medienbaecker.com](https://medienbaecker.com/articles/animate-native-lazy-loading).

- **Jekyll plugin** (using Nokogiri) automatically adds `loading="lazy"` to all `<img>` tags
- **CSS** uses `@media (scripting: enabled)` to set initial `opacity: 0` - progressive enhancement ensures images display normally if JS is disabled
- **JavaScript** adds `.loaded` class when images complete loading, triggering the fade-in

### What's excluded from lazy loading:
- SVG images (no benefit)
- Images with `data-no-lazy` attribute (hero images)
- Images that already have a `loading` attribute

### Accessibility
- Respects `prefers-reduced-motion` - disables transition for users who prefer reduced motion

## Testing

- [x] Hero image loads immediately (no lazy loading)
- [x] Footer/sidebar images fade in when loaded
- [x] SVGs are not lazy loaded
- [x] JavaScript disabled: images display normally
- [x] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)