### PR TITLE
Improve article typography, layout and image sizing

### DIFF
--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -75,10 +75,11 @@ layout: default
       class="
         max-w-3xl lg:max-w-2xl p-3 pb-0
         prose prose-lg
-        prose-headings:font-serif prose-headings:font-normal prose-headings:mb-1 prose-headings:mt-4
-        prose-p:my-0 prose-p:mb-3
+        prose-headings:font-serif prose-headings:font-normal prose-headings:mb-3 prose-headings:mt-4
+        prose-p:my-0 prose-p:mb-4
         prose-h1:text-2xl prose-h1:md:text-3xl
-        prose-h2:text-xl prose-h2:md:text-2xl
+        prose-h2:text-xl prose-h2:md:text-2xl prose-h2:mt-10
+        prose-h3:text-base prose-h3:text-stone-600
         prose-a:text-stone-800 hover:prose-a:text-red-800 prose-a:decoration-2 prose-a:decoration-red-700 prose-a:underline-offset-4 prose-a:underline
       "
     >
@@ -94,10 +95,11 @@ layout: default
       class="
         max-w-3xl lg:max-w-2xl p-3 pt-0
         prose prose-lg
-        prose-headings:font-serif prose-headings:font-normal prose-headings:mb-1 prose-headings:mt-4
-        prose-p:my-0 prose-p:mb-3
+        prose-headings:font-serif prose-headings:font-normal prose-headings:mb-3 prose-headings:mt-4
+        prose-p:my-0 prose-p:mb-4
         prose-h1:text-2xl prose-h1:md:text-3xl
-        prose-h2:text-xl prose-h2:md:text-2xl
+        prose-h2:text-xl prose-h2:md:text-2xl prose-h2:mt-10
+        prose-h3:text-base prose-h3:text-stone-600
         prose-a:text-stone-800 hover:prose-a:text-red-800 prose-a:decoration-2 prose-a:decoration-red-700 prose-a:underline-offset-4 prose-a:underline
       "
     >

--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -1,65 +1,66 @@
 ---
 layout: default
 ---
-<header class="max-w-6xl">
-  {% if jekyll.environment == 'production' %}
-    {% capture image_url_root %}{{site.image_url }}/images/{% endcapture %}
-  {% else %}
-    {% assign image_url_root = '/images/' %}
-  {% endif %}
-  {% if page.image %}
-    <div class="relative">
-      <picture class="sm:rounded">
-        <img
-          sizes="100vw"
-          alt="{{ page.image.alt }}"
-          src="{{ image_url_root }}{{ page.image.base }}.jpg?blur=80&quality=40"
-          srcset="
-            {{ image_url_root }}{{ page.image.base }}.jpg?width=1024.jpg 1024w,
-            {{ image_url_root }}{{ page.image.base }}.jpg?width=1536 1536w,
-            {{ image_url_root }}{{ page.image.base }}.jpg?width=2048 2048w
-          "
-          class="aspect-4/1 w-full sm:rounded sm:px-3"
-          data-no-lazy
-        >
-      </picture>
+{% if jekyll.environment == 'production' %}
+  {% capture image_url_root %}{{site.image_url }}/images/{% endcapture %}
+{% else %}
+  {% assign image_url_root = '/images/' %}
+{% endif %}
 
-      {% if page.image.credit %}
-        <div
-          class="absolute top-3 right-3 sm:right-6 rounded bg-white py-1 px-2 opacity-50 hover:opacity-100"
-        >
-          <p class="text-slate-600 text-xs">
-            <small>
-              <span class="hidden md:inline">image&nbsp;by</span>
-              {% if page.image.source %}
-                <a
-                  href="{{ page.image.source }}"
-                  class="text-slate-600 no-underline hover:text-slate-600 hover:underline"
-                >
-                  {{- page.image.credit -}}
-                </a>
-              {% else %}
-                <span class="text-slate-600 no-underline">{{ page.image.credit }}</span>
-              {% endif %}
-            </small>
-          </p>
-        </div>
-      {% endif %}
+{% if page.image %}
+  <div class="relative w-screen max-w-7xl left-1/2 -translate-x-1/2">
+    <picture>
+      <img
+        sizes="100vw"
+        alt="{{ page.image.alt }}"
+        src="{{ image_url_root }}{{ page.image.base }}.jpg?blur=80&quality=40"
+        srcset="
+          {{ image_url_root }}{{ page.image.base }}.jpg?width=1024.jpg 1024w,
+          {{ image_url_root }}{{ page.image.base }}.jpg?width=1536 1536w,
+          {{ image_url_root }}{{ page.image.base }}.jpg?width=2048 2048w
+        "
+        class="aspect-4/1 w-full object-cover"
+        data-no-lazy
+      >
+    </picture>
 
-      <div class="absolute bottom-0 left-0 z-20 bg-white rounded-tr">
-        {% if page.categories contains 'ruby' %}
-          <a class="inline-block p-3 pb-0" href="/ruby">
-            <img
-              src="/images/onerubything-horizontal.svg"
-              class="w-auto h-4 sm:h-5 md:h-6"
-              alt="One Ruby Thing"
-            >
-          </a>
-        {% endif %}
+    {% if page.image.credit %}
+      <div
+        class="absolute top-3 right-3 sm:right-6 rounded bg-white py-1 px-2 opacity-50 hover:opacity-100"
+      >
+        <p class="text-slate-600 text-xs">
+          <small>
+            <span class="hidden md:inline">image&nbsp;by</span>
+            {% if page.image.source %}
+              <a
+                href="{{ page.image.source }}"
+                class="text-slate-600 no-underline hover:text-slate-600 hover:underline"
+              >
+                {{- page.image.credit -}}
+              </a>
+            {% else %}
+              <span class="text-slate-600 no-underline">{{ page.image.credit }}</span>
+            {% endif %}
+          </small>
+        </p>
       </div>
-    </div>
-  {% endif %}
+    {% endif %}
 
+    <div class="absolute bottom-0 left-[max(0px,calc((min(100vw,80rem)-48rem)/2))] z-20 bg-white rounded-tr">
+      {% if page.categories contains 'ruby' %}
+        <a class="inline-block p-3 pb-0" href="/ruby">
+          <img
+            src="/images/onerubything-horizontal.svg"
+            class="w-auto h-4 sm:h-5 md:h-6"
+            alt="One Ruby Thing"
+          >
+        </a>
+      {% endif %}
+    </div>
+  </div>
+{% endif %}
+
+<div class="max-w-3xl mx-auto">
   <h1 class="font-serif text-xl sm:text-2xl md:text-3xl lg:text-4xl pt-3 px-3">
     {% assign titleWords = page.title | split: ' ' %}
     {% for word in titleWords -%}
@@ -67,13 +68,11 @@ layout: default
       {{- word -}}
     {%- endfor %}
   </h1>
-</header>
 
-<div class="block relative max-w-6xl">
-  <div>
+  <div class="relative">
     <div
       class="
-        max-w-3xl lg:max-w-2xl p-3 pb-0
+        p-3 pb-0
         prose prose-lg
         prose-headings:font-serif prose-headings:font-normal prose-headings:mb-3 prose-headings:mt-4
         prose-p:my-0 prose-p:mb-4
@@ -86,14 +85,14 @@ layout: default
       {{ page.excerpt }}
     </div>
 
-    <div class="grid gap-2 grid-cols-2 lg:grid-cols-1 lg:mx-0 lg:w-1/5 lg:absolute lg:top-5 lg:right-0">
+    <div class="grid gap-2 grid-cols-2 p-3 lg:hidden">
       {% include email.html %}
       {% include rubytshirts.html %}
     </div>
 
     <div
       class="
-        max-w-3xl lg:max-w-2xl p-3 pt-0
+        p-3 pt-0
         prose prose-lg
         prose-headings:font-serif prose-headings:font-normal prose-headings:mb-3 prose-headings:mt-4
         prose-p:my-0 prose-p:mb-4
@@ -105,10 +104,17 @@ layout: default
     >
       {{ content | remove: page.excerpt }}
     </div>
+
+    <aside class="hidden lg:block lg:absolute lg:top-0 lg:left-full lg:ml-6 lg:w-52">
+      <div class="sticky top-4 grid gap-2">
+        {% include email.html %}
+        {% include rubytshirts.html %}
+      </div>
+    </aside>
   </div>
 
   {% if page.categories contains 'ruby' %}
-    <div class="max-w-3xl lg:max-w-2xl -mx-3 p-3 pt-0">
+    <div class="p-3 pt-0">
       {% include email.html %}
     </div>
   {% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,7 +3,7 @@
   {% include head.html %}
 
   <body class="max-w-6xl mx-auto">
-    <div id="nav" class="p-3 pt-5 flex justify-between">
+    <div id="nav" class="p-3 pt-5 flex justify-between max-w-3xl mx-auto">
       <a class="inline-block opacity-80 hover:opacity-100" href="/">
         <img src="/images/andycroll.svg" class="w-auto h-4 sm:h-6 md:h-8" alt="Andy Croll">
       </a>


### PR DESCRIPTION
Redesigns article layout with full-bleed hero images capped at 1280px, centered content column, and separated sidebar CTAs. Improves typography hierarchy with better heading differentiation (H3 in stone-600), increased spacing below headings and paragraphs, and consistent max-width alignment across all components for improved readability.

- Hero image constrained to max-w-7xl instead of viewport width
- Content column standardized to max-w-3xl for readable line length
- Sidebar positioned absolutely outside content on large screens
- H3 styling with smaller size and gray color for better hierarchy
- Increased heading and paragraph spacing for breathing room

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>