### PR TITLE
Homepage redesign with email signup and layout improvements

### DIFF
--- a/_includes/bio.html
+++ b/_includes/bio.html
@@ -1,3 +1,12 @@
-He’s CTO at <a href="https://coveragebook.com">CoverageBook</a>, Rubyist,
+He's CTO at <a href="https://coveragebook.com">CoverageBook</a>, Rubyist,
 Conference Organizer of <a href="https://brightonruby.com">Brighton Ruby</a>,
 Speaker, Bootstrapper <span class="amp text-red-900">&amp;</span> Twin&nbsp;Dad.
+
+{% comment %}
+Alternative bio option (first person, benefit-oriented):
+
+I write about Ruby <span class="amp text-red-900">&amp;</span> Rails, run
+<a href="https://brightonruby.com">Brighton Ruby</a> conference, and build tools
+for the Ruby community. CTO at <a href="https://coveragebook.com">CoverageBook</a>,
+twin&nbsp;dad.
+{% endcomment %}

--- a/_includes/brightonruby.html
+++ b/_includes/brightonruby.html
@@ -1,4 +1,4 @@
-<div class="bg-gradient-to-b from-orange-50 via-transparent via-10% rounded">
+<div class="bg-gradient-to-b from-stone-100 via-transparent via-10% rounded">
   <a
     href="https://brightonruby.com/?utm_source=andycroll.com&utm_medium=banner&utm_campaign=onerubything"
     class="rounded block p-3"

--- a/_includes/email_banner.html
+++ b/_includes/email_banner.html
@@ -13,6 +13,6 @@
 </div>
 {% endif %}
 
-{% if page.url == '/' or page.categories contains 'ruby' %}
+{% if page.url == '/' or page.url == '/ruby/' or page.categories contains 'ruby' %}
 {% include email_popover.html %}
 {% endif %}

--- a/_includes/email_banner.html
+++ b/_includes/email_banner.html
@@ -1,0 +1,18 @@
+{% if page.categories contains 'ruby' %}
+<div class="pointer-events-none fixed inset-x-0 bottom-0 sm:flex sm:justify-center sm:px-6 sm:pb-5 lg:px-8 z-50">
+  <div class="pointer-events-auto flex items-center justify-between gap-x-6 bg-white border border-stone-200 px-6 py-2.5 sm:rounded-xl sm:py-3 sm:pr-3.5 sm:pl-4 shadow-lg">
+    <p class="text-sm/6 text-stone-800">Ruby/Rails techniques, every two weeks</p>
+    <button
+      type="button"
+      onclick="document.getElementById('email-popover').showModal()"
+      class="rounded-md bg-red-700 px-3 py-1.5 text-sm font-semibold text-white hover:bg-red-800 cursor-pointer"
+    >
+      Subscribe
+    </button>
+  </div>
+</div>
+{% endif %}
+
+{% if page.url == '/' or page.categories contains 'ruby' %}
+{% include email_popover.html %}
+{% endif %}

--- a/_includes/email_popover.html
+++ b/_includes/email_popover.html
@@ -1,0 +1,59 @@
+<dialog id="email-popover" class="backdrop:bg-stone-900/50 bg-transparent p-0 max-w-md w-full sm:mx-auto sm:my-auto sm:inset-0">
+  <div class="bg-white rounded-xl shadow-2xl p-6 relative">
+    <button
+      type="button"
+      onclick="document.getElementById('email-popover').close()"
+      class="absolute top-3 right-3 text-stone-400 hover:text-stone-600 cursor-pointer"
+      aria-label="Close"
+    >
+      <svg class="size-5" viewBox="0 0 20 20" fill="currentColor">
+        <path d="M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z"/>
+      </svg>
+    </button>
+
+    <img
+      src="/images/onerubything-horizontal.svg"
+      class="w-auto h-6 mb-4"
+      alt="One Ruby Thing"
+    >
+
+    <form
+      method="post"
+      action="https://goodscary.mailcoach.app/subscribe/a1246c9e-31ea-456a-aa14-7dddfea43c10"
+      target="_blank"
+      novalidate=""
+    >
+      <label for="popover-email" class="block mb-3 text-stone-700">
+        Get a nugget of Ruby knowledge every couple of weeks.
+      </label>
+      <input
+        id="popover-email"
+        name="email"
+        type="email"
+        class="w-full placeholder:text-slate-400 text-slate-800 focus:ring-red-200 ring-stone-200 rounded mb-3 border-stone-300"
+        placeholder="yourname@email.com"
+        required
+      >
+      <input
+        type="submit"
+        value="Subscribe"
+        class="
+          w-full
+          px-4 py-2.5
+          text-sm font-semibold
+          rounded border border-transparent
+          text-white
+          bg-red-700 hover:bg-red-800
+          focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-700
+          cursor-pointer
+        "
+      >
+    </form>
+  </div>
+</dialog>
+
+<script>
+  document.getElementById('email-popover').addEventListener('click', function(e) {
+    if (e.target === this) this.close();
+  });
+</script>

--- a/_includes/firstrubyfriend.html
+++ b/_includes/firstrubyfriend.html
@@ -1,4 +1,4 @@
-<div class="bg-gradient-to-b from-red-50 via-transparent via-10% rounded">
+<div class="bg-gradient-to-b from-stone-100 via-transparent via-10% rounded">
   <a
     href="https://firstrubyfriend.org"
     class="rounded block p-3"

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -4,44 +4,44 @@
   {% assign image_url_root = '/images/' %}
 {% endif %}
 
-<footer role="contentinfo" class="block p-3 mb-10">
-  <div>
+<footer role="contentinfo" class="block mb-10">
+  <div class="p-3 max-w-3xl mx-auto mb-6 text-center">
     <img
       src="{{ image_url_root }}andycroll.jpg"
       alt="Andy Croll headshot"
-      class="aspect-square rounded-full block shadow-lg w-20 md:w-24 mb-4"
+      class="aspect-square rounded-full mx-auto block shadow-lg w-20 md:w-24 mb-4"
       loading="lazy"
     >
 
-    <p class="font-serif text text-lg sm:text-xl md:text-2xl md:w-4/5 lg:w-2/3 mb-4">
+    <p class="font-serif text-lg sm:text-xl md:text-2xl">
       {% include bio.html %}
     </p>
   </div>
 
-  <div class="gap-3 grid lg:grid-cols-5">
-    <div class="md:w-3/4 lg:w-full">
+  <div class="p-3 max-w-7xl mx-auto gap-3 grid lg:grid-cols-5">
+    <div>
       <h5 class="font-medium text-lg font-serif"><a href="https://andycroll.com/ruby">One Ruby Thing</a></h5>
       <p>An email explaining a Ruby/Rails technique every two weeks.</p>
     </div>
 
-    <div class="md:w-3/4 lg:w-full">
+    <div>
       <h5 class="font-medium text-lg font-serif"><a href="https://usingrails.com/">Using Rails</a></h5>
       <p>A community-sourced directory of organisations using and loving Ruby on Rails.</p>
     </div>
 
-    <div class="md:w-3/4 lg:w-full">
+    <div>
       <h5 class="font-medium text-lg font-serif"><a href="https://brightonruby.com/">Brighton Ruby</a></h5>
       <p>The OG, one-day, <i>in-person</i>, single track conference for Rubyists in the UK.</p>
     </div>
 
-    <div class="md:w-3/4 lg:w-full">
+    <div>
       <h5 class="font-medium text-lg font-serif">
         <a href="https://whatthestackpodcast.com/">What The Stack?</a>
       </h5>
       <p>A podcast about the software, hardware, teams & tools folks use to make amazing things.</p>
     </div>
 
-    <div class="md:w-3/4 lg:w-full">
+    <div>
       <h5 class="font-medium text-lg font-serif"><a href="https://firstrubyfriend.org/">First Ruby Friend</a></h5>
       <p>A mentoring programme for the Ruby community.</p>
     </div>

--- a/_includes/rubytshirts.html
+++ b/_includes/rubytshirts.html
@@ -1,4 +1,4 @@
-<div class="bg-gradient-to-b from-red-50 via-transparent via-10% rounded">
+<div class="bg-gradient-to-b from-stone-100 via-transparent via-10% rounded">
   <a
     href="https://rubytshirts.com/?utm_source=andycroll.com&utm_medium=banner&utm_campaign=rubytshirts"
     class="rounded block p-3"

--- a/_includes/usingrails.html
+++ b/_includes/usingrails.html
@@ -1,7 +1,7 @@
-<div class="bg-gradient-to-b from-slate-50 via-transparent via-10% rounded">
+<div class="bg-gradient-to-b from-stone-100 via-transparent via-10% rounded">
   <a
     href="https://usingrails.com/?utm_source=andycroll.com&utm_medium=banner&utm_campaign=usingrails"
-    style="background-image: linear-gradient(178deg, #b91c1c 45px, #FAFAFA 45.5px)"
+    style="background-image: linear-gradient(178deg, #44403c 45px, #f5f5f4 45.5px)"
     class="rounded block p-3"
   >
     <div>

--- a/_includes/whatthestack.html
+++ b/_includes/whatthestack.html
@@ -1,4 +1,4 @@
-<div class="bg-gradient-to-b from-blue-100 via-transparent via-10% rounded">
+<div class="bg-gradient-to-b from-stone-100 via-transparent via-10% rounded">
   <a
     href="https://whatthestackpodcast.com"
     class="rounded block p-3"

--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -85,8 +85,7 @@ layout: default
       {{ page.excerpt }}
     </div>
 
-    <div class="grid gap-2 grid-cols-2 p-3 lg:hidden">
-      {% include email.html %}
+    <div class="p-3 lg:hidden">
       {% include rubytshirts.html %}
     </div>
 
@@ -106,18 +105,11 @@ layout: default
     </div>
 
     <aside class="hidden lg:block lg:absolute lg:top-0 lg:left-full lg:ml-6 lg:w-52">
-      <div class="sticky top-4 grid gap-2">
-        {% include email.html %}
+      <div class="sticky top-4">
         {% include rubytshirts.html %}
       </div>
     </aside>
   </div>
-
-  {% if page.categories contains 'ruby' %}
-    <div class="p-3 pt-0">
-      {% include email.html %}
-    </div>
-  {% endif %}
 
   <div class="mb-10">
     <p class="text-xs text-slate-500 px-3">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,11 +5,11 @@
   <body class="max-w-7xl mx-auto">
     <nav id="nav" class="px-3 py-6 lg:py-8 flex justify-between items-center max-w-3xl mx-auto">
       <a class="inline-block hover:opacity-80 transition-opacity" href="/">
-        <img src="/images/andycroll.svg" class="w-auto h-6 sm:h-8 lg:h-10 xl:h-12" alt="Andy Croll">
+        <img src="/images/andycroll.svg" class="w-auto h-6 sm:h-7 lg:h-8" alt="Andy Croll">
       </a>
 
       <a class="inline-block text-stone-500 hover:text-stone-800 transition-colors" href="/now/">
-        <img src="/images/now.svg" class="w-auto h-6 sm:h-8 lg:h-10 xl:h-12" alt="Now">
+        <img src="/images/now.svg" class="w-auto h-6 sm:h-7 lg:h-8" alt="Now">
       </a>
     </nav>
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,16 +2,16 @@
 <html class="no-js" lang="en">
   {% include head.html %}
 
-  <body class="max-w-6xl mx-auto">
-    <div id="nav" class="p-3 pt-5 flex justify-between max-w-3xl mx-auto">
-      <a class="inline-block opacity-80 hover:opacity-100" href="/">
-        <img src="/images/andycroll.svg" class="w-auto h-4 sm:h-6 md:h-8" alt="Andy Croll">
+  <body class="max-w-7xl mx-auto">
+    <nav id="nav" class="px-3 py-6 lg:py-8 flex justify-between items-center max-w-3xl mx-auto">
+      <a class="inline-block hover:opacity-80 transition-opacity" href="/">
+        <img src="/images/andycroll.svg" class="w-auto h-6 sm:h-8 lg:h-10 xl:h-12" alt="Andy Croll">
       </a>
 
-      <a class="inline-block opacity-50 hover:opacity-100" href="/now/">
-        <img src="/images/now.svg" class="w-auto h-4 sm:h-6 md:h-8 fill-current text-blue-800" alt="Now">
+      <a class="inline-block text-stone-500 hover:text-stone-800 transition-colors" href="/now/">
+        <img src="/images/now.svg" class="w-auto h-6 sm:h-8 lg:h-10 xl:h-12" alt="Now">
       </a>
-    </div>
+    </nav>
 
     <div role="main" class="">
       {{ content | expand_urls: root_url }}
@@ -19,5 +19,6 @@
 
     {% if page.url != '/' %}{% include footer.html %}{% endif %}
     {% include javascripts.html %}
+    {% include email_banner.html %}
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -38,25 +38,23 @@ description: "CTO at CoverageBook, Rubyist, Conference Organizer, Speaker, Boots
 
     <ol class="mt-4">
       {% for post in site.categories.ruby limit: 5 %}
-        <li class="mb-2">
-          <a class="block" href="{{ post.url }}">
+        <li class="mb-1 flex items-baseline justify-between gap-3">
+          <a href="{{ post.url }}">
             {% assign titleWords = post.title | split: ' ' %}
             {% for word in titleWords -%}
               {%- if forloop.last %}&nbsp;{% else %}  {% endif -%}
               {{- word -}}
             {%- endfor %}
           </a>
-          <small class="text-gray-400">{{ post.date | date_to_long_string: 'ordinal', 'US' }}</small>
+          <small class="flex-none text-gray-400">{{ post.date | date_to_string: 'ordinal', 'US' }}</small>
         </li>
       {% endfor %}
     </ol>
 
     <a
       href="/ruby/"
-      class="inline-block items-center px-3 py-2 border border-transparent rounded shadow-xs font-medium no-underline text-gray-100 bg-red-800 hover:bg-red-700 hover:text-white hover:no-underline hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-700 cursor-pointer"
-    >
-      100+ articles</a
-    >
+      class="block text-right text-stone-800 hover:text-red-800 underline decoration-2 decoration-red-700 underline-offset-4"
+    >100+ articles &rarr;</a>
   </div>
 
   <div class="grid gap-4 grid-cols-2 content-start">
@@ -93,8 +91,10 @@ description: "CTO at CoverageBook, Rubyist, Conference Organizer, Speaker, Boots
 
       {% endif %}
     {% endfor %}
-    <li>
-      <a href="/other/">View all &rarr;</a>
-    </li>
   </ol>
+
+  <a
+    href="/other/"
+    class="block text-right text-stone-800 hover:text-red-800 underline decoration-2 decoration-red-700 underline-offset-4"
+  >View all &rarr;</a>
 </div>

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@ description: "CTO at CoverageBook, Rubyist, Conference Organizer, Speaker, Boots
   </h1>
 </header>
 
-<div class="grid grid-cols-1 lg:grid-cols-2 gap-6 px-3 max-w-7xl mx-auto">
+<div class="grid grid-cols-1 lg:grid-cols-2 gap-6 lg:gap-10 px-3 max-w-7xl mx-auto">
   <div class="bg-gradient-to-b from-slate-50 via-transparent via-30% rounded p-3">
     <a class="block" href="/ruby/">
       <img
@@ -53,11 +53,11 @@ description: "CTO at CoverageBook, Rubyist, Conference Organizer, Speaker, Boots
 
     <a
       href="/ruby/"
-      class="block text-right text-stone-800 hover:text-red-800 underline decoration-2 decoration-red-700 underline-offset-4"
+      class="block text-right text-sm mt-2 text-stone-800 hover:text-red-800 underline decoration-2 decoration-red-700 underline-offset-4"
     >100+ articles &rarr;</a>
   </div>
 
-  <div class="grid gap-4 grid-cols-2 content-start">
+  <div class="grid gap-6 lg:gap-10 grid-cols-2 content-start">
     {% include rubytshirts.html %}
     {% include usingrails.html %}
     {% include firstrubyfriend.html %}
@@ -95,6 +95,6 @@ description: "CTO at CoverageBook, Rubyist, Conference Organizer, Speaker, Boots
 
   <a
     href="/other/"
-    class="block text-right text-stone-800 hover:text-red-800 underline decoration-2 decoration-red-700 underline-offset-4"
+    class="block text-right text-sm mt-2 text-stone-800 hover:text-red-800 underline decoration-2 decoration-red-700 underline-offset-4"
   >View all &rarr;</a>
 </div>

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@ description: "CTO at CoverageBook, Rubyist, Conference Organizer, Speaker, Boots
   </h1>
 </header>
 
-<div class="grid grid-cols-1 lg:grid-cols-2 gap-6 px-3">
+<div class="grid grid-cols-1 lg:grid-cols-2 gap-6 px-3 max-w-7xl mx-auto">
   <div class="bg-gradient-to-b from-slate-50 via-transparent via-30% rounded p-3">
     <a class="block" href="/ruby/">
       <img

--- a/index.html
+++ b/index.html
@@ -2,14 +2,14 @@
 layout: default
 description: "CTO at CoverageBook, Rubyist, Conference Organizer, Speaker, Bootstrapper & Twin Dad."
 ---
-<header class="block p-3 mb-4">
-  <h1 class="font-serif text sm:text-lg md:text-3xl md:w-3/4 xl:w-1/2">
+<header class="block p-3 mb-6 max-w-3xl mx-auto">
+  <h1 class="font-serif text sm:text-lg md:text-3xl">
     {% include bio.html %}
   </h1>
 </header>
 
-<div class="grid grid-flow-dense grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
-  <div class="col-span-2 bg-gradient-to-b from-slate-50 via-transparent via-30% rounded p-3">
+<div class="grid grid-cols-1 lg:grid-cols-2 gap-6 px-3">
+  <div class="bg-gradient-to-b from-slate-50 via-transparent via-30% rounded p-3">
     <a class="block" href="/ruby/">
       <img
         src="/images/onerubything-horizontal.svg"
@@ -18,15 +18,26 @@ description: "CTO at CoverageBook, Rubyist, Conference Organizer, Speaker, Boots
       >
     </a>
 
-    <p class="text-lg mb-3">
-      An email newsletter, with one Ruby/Rails technique delivered with a ‘why?’ and a ‘how?’ every two weeks. It’s
+    <p class="text-lg mb-4">
+      An email newsletter, with one Ruby/Rails technique delivered with a 'why?' and a 'how?' every two weeks. It's
       deliberately brief, focussed
       <span class="amp text-red-900">&amp;</span>
       opinionated.
     </p>
 
-    <ol>
-      {% for post in site.categories.ruby limit: 10 %}
+    <div class="flex items-center justify-between gap-x-4 bg-white border border-stone-200 px-4 py-2.5 rounded-xl shadow-sm">
+      <p class="text-sm/6 text-stone-800">Ruby/Rails techniques, every two weeks</p>
+      <button
+        type="button"
+        onclick="document.getElementById('email-popover').showModal()"
+        class="flex-none rounded-md bg-red-700 px-3 py-1.5 text-sm font-semibold text-white hover:bg-red-800 cursor-pointer"
+      >
+        Subscribe
+      </button>
+    </div>
+
+    <ol class="mt-4">
+      {% for post in site.categories.ruby limit: 5 %}
         <li class="mb-2">
           <a class="block" href="{{ post.url }}">
             {% assign titleWords = post.title | split: ' ' %}
@@ -48,47 +59,42 @@ description: "CTO at CoverageBook, Rubyist, Conference Organizer, Speaker, Boots
     >
   </div>
 
-  <div class="col-span-2 md:col-span-1 lg:col-span-2 grid gap-3 grid-cols-2 md:grid-cols-1 lg:grid-cols-2 grid-flow-dense">
+  <div class="grid gap-4 grid-cols-2 content-start">
     {% include rubytshirts.html %}
     {% include usingrails.html %}
     {% include firstrubyfriend.html %}
     {% include whatthestack.html %}
     {% include brightonruby.html %}
-
-    <div class="col-span-2 md:col-span-1 lg:col-span-2 bg-gradient-to-b from-slate-50 via-transparent via-10% rounded p-3">
-      <h2 class="font-serif bold text-lg">
-        <a href="/other/">Other Archives</a>
-      </h2>
-
-      <ol class="w-full">
-        {% assign other_post_count = 0 %}
-        {% for post in site.posts %}
-          {% if post.categories contains 'ruby' %}
-          {% elsif other_post_count < 5 %}
-            <li class="mb-1 flex items-baseline justify-between gap-3">
-              <a href="{{ post.url }}">
-                {% assign titleWords = post.title | split: ' ' %}
-                {% for word in titleWords -%}
-                  {%- if forloop.last %}&nbsp;{% else %}  {% endif -%}
-                  {{- word -}}
-                {%- endfor %}
-              </a>
-              <small class="flex-none text-gray-400"> {{ post.date | date_to_string: 'ordinal', 'US' }}</small>
-            </li>
-            {% assign other_post_count = other_post_count | plus: 1 %}
-          {% else %}
-
-          {% endif %}
-        {% endfor %}
-        <li class="mb-1 flex items-baseline justify-between gap-3">
-          <a
-            href="/other/"
-            class=""
-          >
-            &amp; more articles&hellip;</a
-          >
-        </li>
-      </ol>
-    </div>
   </div>
+</div>
+
+<div class="mt-8 p-3 max-w-3xl mx-auto">
+  <h2 class="font-serif text-lg mb-2">
+    <a href="/other/">Other Archives</a>
+  </h2>
+
+  <ol>
+    {% assign other_post_count = 0 %}
+    {% for post in site.posts %}
+      {% if post.categories contains 'ruby' %}
+      {% elsif other_post_count < 3 %}
+        <li class="mb-1 flex items-baseline justify-between gap-3">
+          <a href="{{ post.url }}">
+            {% assign titleWords = post.title | split: ' ' %}
+            {% for word in titleWords -%}
+              {%- if forloop.last %}&nbsp;{% else %}  {% endif -%}
+              {{- word -}}
+            {%- endfor %}
+          </a>
+          <small class="flex-none text-gray-400">{{ post.date | date_to_string: 'ordinal', 'US' }}</small>
+        </li>
+        {% assign other_post_count = other_post_count | plus: 1 %}
+      {% else %}
+
+      {% endif %}
+    {% endfor %}
+    <li>
+      <a href="/other/">View all &rarr;</a>
+    </li>
+  </ol>
 </div>

--- a/now.md
+++ b/now.md
@@ -1,7 +1,7 @@
 ---
 layout: article
 title: "What I'm Doing Now"
-date: "2024-05-26"
+date: "2026-01-28"
 redirect_from:
   - /2010/10/01/negative/
   - /startups/singapore/singapore-startup-negativity/
@@ -22,13 +22,17 @@ image:
 description: "The current work of Andy Croll"
 ---
 
-I’m CTO at [CoverageBook](https://coveragebook.com).
+I'm CTO at [CoverageBook](https://coveragebook.com), building new features and exploring how AI can improve our product.
 
-Co-chaired [RailsConf 2024](https://railsconf.com) ([by accident](/ruby/railsconf-detroit-2024-cochairs-perspective/)) in Detroit, Michigan.
+Running [One Ruby Thing](/ruby/), a fortnightly email newsletter about Ruby and Rails techniques.
 
-What I thought of [2023](/other/year-in-review-2023/).
+Planning [Brighton Ruby 2026](https://brightonruby.com).
 
-### Past Speaking
+Excited about Rails 8, Solid Queue, Solid Cache, Hotwire improvements, and taming the robot army now at my fingertips.
+
+What I thought of [2025](/other/year-in-review-2025/).
+
+### [Past Speaking](https://rubyevents.org/speakers/andy-croll)
 
 - [Taylor’s Guide to Big Rewrites](https://www.youtube.com/watch?v=G1QbH2QZX08) RailsConf 2023 & RailSaaS Athens 2023
 - [The Mrs Triggs Problem](https://www.youtube.com/watch?v=0UcTD49KugA) Keynoted Euruko Helsinki 2022 & [RailsConf 2022](https://www.youtube.com/watch?v=QbcSsDUyW6s)

--- a/ruby/index.html
+++ b/ruby/index.html
@@ -1,47 +1,51 @@
 ---
 layout: default
-description: "An email newsletter, with one Ruby/Rails technique delivered with a ‘why?’ and a ‘how?’ every two weeks.
-It’s deliberately brief, focussed & opinionated."
+description: "An email newsletter, with one Ruby/Rails technique delivered with a 'why?' and a 'how?' every two weeks.
+It's deliberately brief, focussed & opinionated."
 redirect_from:
 - /one-ruby-thing
 ---
 
-<header class="block p-3 mb-4">
-  <a class="inline-block" href="/ruby/">
+<header class="block p-3 mb-6 max-w-3xl mx-auto">
+  <a class="inline-block mb-2" href="/ruby/">
     <img
       src="/images/onerubything-horizontal.svg"
-      class="w-auto h-4 sm:h-6 md:h-8"
+      class="w-auto h-6 mb-2"
       alt="One Ruby Thing"
     >
   </a>
 
-  <h1 class="font-serif text sm:text-lg md:text-3xl md:w-4/5 lg:w-2/3">
-    An email newsletter, with one Ruby/Rails technique delivered with a ‘why?’ and a ‘how?’ every two weeks. It’s deliberately brief, focussed
+  <p class="text-lg mb-4">
+    An email newsletter, with one Ruby/Rails technique delivered with a 'why?' and a 'how?' every two weeks. It's deliberately brief, focussed
     <span class="amp text-red-900">&amp;</span>
     opinionated.
-  </h1>
+  </p>
+
+  <div class="flex items-center justify-between gap-x-4 bg-white border border-stone-200 px-4 py-2.5 rounded-xl shadow-sm">
+    <p class="text-sm/6 text-stone-800">Ruby/Rails techniques, every two weeks</p>
+    <button
+      type="button"
+      onclick="document.getElementById('email-popover').showModal()"
+      class="flex-none rounded-md bg-red-700 px-3 py-1.5 text-sm font-semibold text-white hover:bg-red-800 cursor-pointer"
+    >
+      Subscribe
+    </button>
+  </div>
 </header>
 
-  <div class="grid md:grid-cols-5">
-    <div class="p-3 md:col-span-3">
-      <ol>
-        {% for post in site.categories.ruby %}
-          <li class="mb-2">
-            <a class="block" href="{{ post.url }}">
-              {% assign titleWords = post.title | split: ' ' %}
-              {% for word in titleWords -%}
-                {%- if forloop.last %}&nbsp;{% else %}  {% endif -%}
-                {{- word -}}
-              {%- endfor %}
-            </a>
-            <small class="text-gray-400">{{ post.date | date_to_long_string: 'ordinal', 'US' }}</small>
-          </li>
-        {% endfor %}
-      </ol>
-    </div>
-
-    <div class="md:col-span-2">
-      {% include email.html %}
-    </div>
-  </div>
+<div class="p-3 max-w-3xl mx-auto">
+  <ol>
+    {% for post in site.categories.ruby %}
+      <li class="mb-1 flex items-baseline justify-between gap-3">
+        <a href="{{ post.url }}">
+          {% assign titleWords = post.title | split: ' ' %}
+          {% for word in titleWords -%}
+            {%- if forloop.last %}&nbsp;{% else %}  {% endif -%}
+            {{- word -}}
+          {%- endfor %}
+        </a>
+        <small class="flex-none text-gray-400">{{ post.date | date_to_string: 'ordinal', 'US' }}</small>
+      </li>
+    {% endfor %}
+  </ol>
 </div>


### PR DESCRIPTION
## Summary

- Add email signup system with sticky floating banner (article pages) and inline subscribe button (homepage)
- Create modal popover for email subscription form using Mailcoach
- Unify project card gradients to monochromatic stone-100 palette
- Restructure homepage layout: bio centered at max-w-3xl, main content at max-w-7xl
- Reduce article list from 10 to 5 items
- Move Other Archives section below main grid
- Remove inline email forms from article layout (use floating banner instead)
- Scale navbar logos appropriately for different screen sizes
- Constrain homepage grid width for better wide-screen layout

## Test plan

- [ ] Verify email subscribe button opens popover on homepage
- [ ] Verify floating banner appears on Ruby article pages
- [ ] Verify popover form submits to Mailcoach
- [ ] Test responsive layout at various breakpoints
- [ ] Verify project cards all use consistent stone gradients

🤖 Generated with [Claude Code](https://claude.com/claude-code)