### PR TITLE
Fix jekyll-tailwind GitHub link

### DIFF
--- a/_posts/2026/2026-01-27-simple-tailwind-css-4-setup-for-jekyll.md
+++ b/_posts/2026/2026-01-27-simple-tailwind-css-4-setup-for-jekyll.md
@@ -23,7 +23,7 @@ Changes to four files, plus one more step if you want plugins.
 gem "jekyll-tailwind", group: [:jekyll_plugins]
 ```
 
-Run `bundle install` to fetch the gem. The [`jekyll-tailwind`](https://github.com/vormwald/jekyll-tailwind) gem handles everything. No separate build pipeline, no PostCSS config, no watching for changes. It hooks into Jekyll's build process.
+Run `bundle install` to fetch the gem. The [`jekyll-tailwind`](https://github.com/crbelaus/jekyll-tailwind) gem handles everything. No separate build pipeline, no PostCSS config, no watching for changes. It hooks into Jekyll's build process.
 
 Under the hood, it uses [`tailwindcss-ruby`](https://github.com/flavorjones/tailwindcss-ruby)---the same gem that powers Tailwind in Rails.
 


### PR DESCRIPTION
## Summary
Fixed incorrect GitHub repository link for jekyll-tailwind gem in the Tailwind CSS 4 setup article.

The link now points to the correct repository owner (crbelaus instead of vormwald).

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>