### PR TITLE
Add Render build configuration for preview deployments

### DIFF
--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -o errexit
+
+bundle install
+
+if [[ "${IS_PULL_REQUEST}" == "true" ]]; then
+    echo "Preview: building with --future"
+    JEKYLL_ENV=production bundle exec jekyll build --future
+else
+    echo "Production build"
+    JEKYLL_ENV=production bundle exec jekyll build
+fi

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,12 @@
+services:
+  - type: web
+    runtime: static
+    name: andycroll-blog
+    repo: https://github.com/andycroll/andycroll.com
+    branch: main
+    buildCommand: ./bin/render-build.sh
+    staticPublishPath: ./_site
+    envVars:
+      - key: RUBY_VERSION
+        value: 3.4.4
+    previewsEnabled: true


### PR DESCRIPTION
## Summary
- Add `render.yaml` for Infrastructure as Code deployment config
- Add conditional build script that uses `--future` flag in PR previews
- Enables automatic PR preview deployments with future-dated posts visible

## Next Steps
After merge, enable "PR Previews" in Render dashboard if not already enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)