### PR TITLE
Update Brighton Ruby date to 2026 (June 25th)

### DIFF
--- a/_includes/brightonruby.html
+++ b/_includes/brightonruby.html
@@ -6,14 +6,14 @@
     <div>
       <img
         src="/images/brightonruby-horizontal.svg"
-        alt="Brighton Ruby 2024"
+        alt="Brighton Ruby 2026"
         class="w-auto h-6 mb-2 dark:invert"
         loading="lazy"
       >
       <p class="text-sm m-0 font-semibold leading-6 ">
         The UK’s friendliest, Ruby & Rails event.
         <br class="hidden sm:block">
-        Thursday 19th&nbsp;June, 2025.
+        Thursday 25th&nbsp;June, 2026.
         <br class="hidden sm:block">
         Includes ice cream<span aria-hidden="true">&nbsp;&rarr;</span>
       </p>


### PR DESCRIPTION
The previous date (June 19th, 2025) has passed. Updated to the upcoming Brighton Ruby 2026 conference date and fixed the alt text year from 2024 to 2026.

https://claude.ai/code/session_01AZTdr1UjYEES74LqB6VaeR