### PR TITLE
Fix Render deploy by removing stale bin/bundle binstub

### DIFF
--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -o errexit
 
+rm -f bin/bundle
 bundle install
 
 if [[ "${IS_PULL_REQUEST}" == "true" ]]; then


### PR DESCRIPTION
Render builds were failing with "Your bin/bundle was not generated by Bundler" because a stale `bin/bundle` binstub from a previous Bundler version was persisted in the build cache. This adds `rm -f bin/bundle` to the build script to clean it up before `bundle install`.