### PR TITLE
Fix update_columns example in except_on article

### DIFF
--- a/_posts/2025/2025-12-22-except_on-conditional-validations.md
+++ b/_posts/2025/2025-12-22-except_on-conditional-validations.md
@@ -36,6 +36,7 @@ end
 class User < ApplicationRecord
   def self.admin_create(attributes)
     user = new(attributes)
+    user.save
     user.update_columns(attributes)  # No validations, no callbacks
   end
 end


### PR DESCRIPTION
## Summary
- Adds `user.save` before `update_columns` in the anti-pattern example in the except_on article
- `update_columns` requires a persisted record to work, so calling it on an unsaved `new` record would raise an error

🤖 Generated with [Claude Code](https://claude.com/claude-code)