### PR TITLE
Add Content-Signal directive to robots.txt

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,4 +1,5 @@
 User-agent: *
 Allow: /
+Content-Signal: ai-train=no, search=yes, ai-input=no
 
 Sitemap: https://andycroll.com/sitemap.xml


### PR DESCRIPTION
Declares AI content usage preferences via the [Content Signals](https://contentsignals.org/) standard: `search=yes` keeps search engines indexing normally, while `ai-train=no` and `ai-input=no` opt out of AI training and AI grounding/input use.

---

[![Compound Engineering v2.54.1](https://img.shields.io/badge/Compound_Engineering-v2.54.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.7 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)