### PR TITLE
Fix broken XSS protection link in html_safe post

### DIFF
--- a/_posts/2026/2026-05-04-alternatives-to-html-safe-in-rails.md
+++ b/_posts/2026/2026-05-04-alternatives-to-html-safe-in-rails.md
@@ -11,7 +11,7 @@ image:
   source: "https://unsplash.com/photos/yellow-and-black-striped-textile-KPDDc1DeP4Y"
 ---
 
-When you need to build HTML outside of a template, it's tempting to concatenate strings and call `html_safe` on the result. This bypasses Rails's built-in [XSS protection](/ruby/2023/07/17/beware-of-raw-erb/) entirely: any user input in that string goes straight to the browser unescaped.
+When you need to build HTML outside of a template, it's tempting to concatenate strings and call `html_safe` on the result. This bypasses Rails's built-in [XSS protection](/ruby/beware-of-raw-erb/) entirely: any user input in that string goes straight to the browser unescaped.
 
 The good news is you almost never need `html_safe`. Rails provides three underappreciated tools that handle escaping for you.
 


### PR DESCRIPTION
## Summary
- The XSS protection link in the 2026-05-04 `html_safe` post used the old date-based URL format (`/ruby/2023/07/17/beware-of-raw-erb/`)
- Site permalinks are `/:categories/:title/`, so the correct path is `/ruby/beware-of-raw-erb/`

## Test plan
- [ ] Verify the link resolves to the `beware-of-raw-erb` post on the deployed site

🤖 Generated with [Claude Code](https://claude.com/claude-code)