### PR TITLE
Show array shortcut for class: in tag helpers (class_names post)

### DIFF
--- a/_posts/2026/2026-05-11-use-class-names-to-conditionally-apply-css-classes.md
+++ b/_posts/2026/2026-05-11-use-class-names-to-conditionally-apply-css-classes.md
@@ -37,31 +37,42 @@ When you're building views in Rails, you often need to apply CSS classes conditi
 <% end %>
 ```
 
-`String` arguments (like `"p-4 rounded"`) are always applied. The trailing `Hash` (the keyword-style arguments) includes any key whose value is truthy and silently drops the rest.
+`String` arguments are always applied; trailing keyword-style entries are included when their value is truthy and silently dropped otherwise.
+
+Better still — Rails tag helpers (`tag.*`, `link_to`, form builders) already run the `class:` argument through the process implicitly, so you can drop the wrapper and hand it an array directly. The trailing `key: value` pairs don't need their own `{}` either; Ruby wraps them into a `Hash` for you:
+
+```erb
+<%= tag.div class: [
+  "p-4 rounded",
+  "bg-red-50 border-red-500": @error,
+  "opacity-50 cursor-not-allowed": @disabled
+] do %>
+  <%= @message %>
+<% end %>
+```
 
 An active nav link:
 
 ```erb
 <%= link_to "Home", root_path,
-  class: class_names("nav-link px-3 py-2",
-    "text-blue-700 font-semibold": current_page?(root_path)) %>
+  class: ["nav-link px-3 py-2",
+    "text-blue-700 font-semibold": current_page?(root_path)] %>
 ```
 
 A form field with errors:
 
 ```erb
 <%= f.text_field :email,
-  class: class_names("field",
-    "field--error": @user.errors[:email].any?) %>
+  class: ["field", "field--error": @user.errors[:email].any?] %>
 ```
 
 A flash message:
 
 ```erb
 <% flash.each do |type, message| %>
-  <%= tag.p message, class: class_names("flash",
+  <%= tag.p message, class: ["flash",
     notice: type == "notice",
-    alert: type == "alert") %>
+    alert: type == "alert"] %>
 <% end %>
 ```
 
@@ -69,10 +80,10 @@ An active tab:
 
 ```erb
 <%= link_to "Overview", project_path(@project),
-  class: class_names("tab", "tab--active": current_page?(project_path(@project))) %>
+  class: ["tab", "tab--active": current_page?(project_path(@project))] %>
 ```
 
-Or wrap a repeated pattern in a helper:
+Or wrap a repeated pattern in a helper. Helpers often return `String`s, which would be a case where you call `class_names` directly:
 
 ```ruby
 def class_names_for_project(project)
@@ -90,9 +101,9 @@ end
 
 The unsophisticated approach ends up with extra whitespace in the rendered HTML with ERB tags inside an HTML attribute (which I'm not a fan of visually), plus it's hard to scan which classes are always present and which are conditional.
 
-`class_names` returns an HTML-safe string, so you don't need to worry about escaping. It also splits whitespace-separated tokens and deduplicates them, so `class_names("p-4", "p-4 rounded")` collapses to `"p-4 rounded"` rather than repeating `p-4`.
+The tag helpers call `token_list` on whatever you pass to `class:`, which is aliased as `class_names`. It splits whitespace-separated tokens, deduplicates them, and returns an HTML-safe string. So `["p-4", "p-4 rounded"]` collapses to `"p-4 rounded"` rather than repeating `p-4`.
 
-It's available in any view or helper in Rails, since it's defined in `ActionView::Helpers::TagHelper`. You might also see it referred to as `token_list`, which is the original method name.
+You have to call `class_names` directly when you're not inside a tag helper — building a string in a helper method, or interpolating into raw HTML. It's available in all views and helpers in Rails since it's defined in `ActionView::Helpers::TagHelper`. You might also see it referred to as `token_list`, which is the original method name.
 
 ## Why not?
 
@@ -102,8 +113,8 @@ If you've only got a single conditional class, plain ERB is readable enough:
 <div class="p-4 <%= 'font-bold' if @important %>">
 ```
 
-Though `class_names` does avoid the awkward whitespace issue when the condition is false:
+Though the array form does avoid the awkward whitespace issue when the condition is false:
 
 ```erb
-<%= tag.div class: class_names("p-4", "font-bold": @important) do %>
+<%= tag.div class: ["p-4", "font-bold": @important] do %>
 ```


### PR DESCRIPTION
## Summary

Updates the `class_names` post (`_posts/2026/2026-05-11-…`) to show that Rails tag helpers (`tag.*`, `link_to`, form builders) already run the `class:` argument through `token_list`/`class_names` — so you can drop the explicit wrapper and pass an array (with a trailing hash, no `{}` needed) directly. The first example shows both forms for progression; the variant examples are rewritten in the array form. The helper-method example keeps `class_names` since it needs to return a `String`.

## Test plan

- [ ] `bundle exec jekyll serve --future` and eyeball the rendered post for code-block syntax highlighting and prose flow.