### PR TITLE
Migrate to Cloudflare Workers and route images through Image Transformations

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,12 +1,33 @@
 name: Deploy
 
 on:
-  schedule:
-    - cron: "0 0/6 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-    - name: Trigger Render.com Hook
-      run: curl -X POST ${{ secrets.render_deploy_hook }}
+      - uses: actions/checkout@v6
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Build site
+        env:
+          JEKYLL_ENV: production
+          LANG: C.UTF-8
+          LC_ALL: C.UTF-8
+        run: bundle exec jekyll build
+
+      - name: Deploy to Cloudflare
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Personal website and blog for Andy Croll (andycroll.com), built with Jekyll and deployed to Netlify. The site features Ruby/Rails technical articles under the "One Ruby Thing" brand, plus personal/conference content.
+Personal website and blog for Andy Croll (andycroll.com), built with Jekyll and deployed to Cloudflare Workers (static assets). The site features Ruby/Rails technical articles under the "One Ruby Thing" brand, plus personal/conference content.
 
 ## Commands
 
@@ -42,7 +42,7 @@ bundle exec jekyll post "Post Title"
 - `_layouts/` - `default.html` (base) and `article.html` (blog posts)
 - `_includes/` - Reusable components (email signup, project promos, footer)
 
-**Images**: Production images served from `https://images.andycroll.com`, local `/images/` in development. Image URLs use query parameters for responsive sizing (e.g., `?width=1024`).
+**Images**: All raster images live in `/images/` in the repo and ship in `_site/`. In production they are routed through Cloudflare Image Transformations via the `_includes/cf_image.html` partial, which prepends `/cdn-cgi/image/format=auto,width=…/` to the path. In development the raw `/images/...` path is used so `jekyll serve` resolves files locally. SVGs are emitted as-is; only raster sources should go through `cf_image`.
 
 **Categories**: Posts use `category: ruby` for Ruby/Rails content. The homepage displays recent Ruby posts prominently.
 
@@ -65,4 +65,6 @@ image:
 
 ## Deployment
 
-Hosted on Render. Production builds automatically on push to main. Auto deploys every six hours using GitHub Actions to trigger a deploy hook.
+Deployed to a Cloudflare Worker named `andycroll-com` via `wrangler.jsonc` (static assets pointing at `_site`). The `.github/workflows/deploy.yml` workflow is `workflow_dispatch`-only — it runs `bundle exec jekyll build` under `LANG=C.UTF-8` and then `cloudflare/wrangler-action@v3 deploy`. Requires `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` repo secrets.
+
+`render.yaml`, `bin/render-build.sh`, and `netlify.toml` remain in place until DNS cuts over to Cloudflare; remove them in a follow-up.

--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,6 @@ author: Andy Croll
 description: "CTO at CoverageBook, Rubyist, Conference Organizer, Speaker, Bootstrapper & Twin Dad."
 
 base_url: ""
-image_url: "https://images.andycroll.com"
 
 include: ["_headers"]
 exclude: ["scripts", "bin"]

--- a/_headers
+++ b/_headers
@@ -1,6 +1,5 @@
 /*
-  Content-Security-Policy: default-src 'self' cdn.usefathom.com; script-src 'self' *.andycroll.com instant.page cdn.usefathom.com; img-src 'self' images.andycroll.com cdn.usefathom.com data: *.andycroll.com
-  Link: <https://images.andycroll.com/>; rel=preconnect; crossorigin
+  Content-Security-Policy: default-src 'self' cdn.usefathom.com; script-src 'self' *.andycroll.com instant.page cdn.usefathom.com; img-src 'self' cdn.usefathom.com data: *.andycroll.com
   Link: <https://cdn.usefathom.com/>; rel=preconnect; crossorigin
   Link: </llms.txt>; rel="describedby"; type="text/plain"
   Link: </index.xml>; rel="alternate"; type="application/atom+xml"; title="Atom feed"

--- a/_includes/cf_image.html
+++ b/_includes/cf_image.html
@@ -1,0 +1,30 @@
+{%- comment -%}
+Render an image src that, in production, is routed through Cloudflare Image
+Transformations (/cdn-cgi/image/...). In development the original path is used
+so jekyll serve can resolve it locally.
+
+Params:
+  src     (required) — path like "/images/2025/foo.jpg" or "images/2025/foo.jpg"
+  width   (optional) — pixels
+  height  (optional) — pixels
+  fit     (optional) — Cloudflare fit mode, defaults to "cover"
+  blur    (optional) — Cloudflare blur 1–250
+  quality (optional) — 1–100
+{%- endcomment -%}
+{%- assign src = include.src -%}
+{%- unless src contains "://" -%}
+{%- assign first_char = src | slice: 0 -%}
+{%- unless first_char == "/" -%}{%- assign src = "/" | append: src -%}{%- endunless -%}
+{%- endunless -%}
+{%- if jekyll.environment == "production" -%}
+{%- assign opts = "format=auto" -%}
+{%- if include.width -%}{%- assign opts = opts | append: ",width=" | append: include.width -%}{%- endif -%}
+{%- if include.height -%}{%- assign opts = opts | append: ",height=" | append: include.height -%}{%- endif -%}
+{%- assign fit = include.fit | default: "cover" -%}
+{%- if include.width or include.height -%}{%- assign opts = opts | append: ",fit=" | append: fit -%}{%- endif -%}
+{%- if include.blur -%}{%- assign opts = opts | append: ",blur=" | append: include.blur -%}{%- endif -%}
+{%- if include.quality -%}{%- assign opts = opts | append: ",quality=" | append: include.quality -%}{%- endif -%}
+/cdn-cgi/image/{{ opts }}{{ src }}
+{%- else -%}
+{{ src }}
+{%- endif -%}

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,13 +1,7 @@
-{% if jekyll.environment == 'production' %}
-  {% capture image_url_root %}{{ site.image_url }}/images/{% endcapture %}
-{% else %}
-  {% assign image_url_root = '/images/' %}
-{% endif %}
-
 <footer role="contentinfo" class="block mb-10">
   <div class="p-3 max-w-3xl mx-auto mb-6 text-center">
     <img
-      src="{{ image_url_root }}andycroll.jpg"
+      src="{% include cf_image.html src='/images/andycroll.jpg' width=192 %}"
       alt="Andy Croll headshot"
       class="aspect-square rounded-full mx-auto block shadow-lg w-20 md:w-24 mb-4"
       loading="lazy"

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,6 +8,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
   {% assign imagebase = page.image.base %}
+  {% if imagebase %}{% capture imagebase_src %}/images/{{ imagebase }}.jpg{% endcapture %}{% endif %}
   {% capture canonical %}{{ site.url }}{% if site.permalink contains '.html' %}{{ page.url }}{% else %}{{ page.url | remove:'index.html' | strip_slash }}{% endif %}{% endcapture %}
 
   <title>
@@ -26,7 +27,7 @@
 
   <meta property="og:type" content="article">
   {% if imagebase %}
-    <meta property="og:image" content="{{ site.image_url }}/images/{{ imagebase }}.jpg?width=1024">
+    <meta property="og:image" content="{{ site.url }}{% include cf_image.html src=imagebase_src width=1200 %}">
   {% endif %}
   <link rel="og:url" href="{{ canonical }}">
 
@@ -37,10 +38,10 @@
 
   {% if imagebase %}
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:image" content="{{ site.image_url }}/images/{{ imagebase }}.jpg?width=1024">
+    <meta name="twitter:image" content="{{ site.url }}{% include cf_image.html src=imagebase_src width=1200 %}">
   {% else %}
     <meta name="twitter:card" content="summary">
-    <meta name="twitter:image" content="{{ root_url }}/images/andycroll.jpg">
+    <meta name="twitter:image" content="{{ site.url }}{% include cf_image.html src='/images/andycroll.jpg' width=512 %}">
   {% endif %}
 
   <link rel="canonical" href="{{ canonical }}">
@@ -66,7 +67,7 @@
     "@id": "{{ site.url }}/#person",
     "name": "Andy Croll",
     "url": "{{ site.url }}",
-    "image": "{{ site.image_url }}/images/andycroll.jpg",
+    "image": "{{ site.url }}{% include cf_image.html src='/images/andycroll.jpg' width=512 %}",
     "jobTitle": "CTO",
     "worksFor": {
       "@type": "Organization",
@@ -114,7 +115,7 @@
     "mainEntityOfPage": { "@id": "{{ canonical }}" },
     "isPartOf": { "@id": "{{ site.url }}/#website" }
     {% if page.image.base %},
-    "image": "{{ site.image_url }}/images/{{ page.image.base }}.jpg?width=1200"
+    "image": "{{ site.url }}{% include cf_image.html src=imagebase_src width=1200 %}"
     {% endif %}
     {% if page.category %},
     "articleSection": "{{ page.category | capitalize }}"

--- a/_includes/rubytshirts.html
+++ b/_includes/rubytshirts.html
@@ -5,7 +5,7 @@
   >
     <div>
       <img
-        src="/images/rubytshirts-horizontal.png"
+        src="{% include cf_image.html src='/images/rubytshirts-horizontal.png' height=48 %}"
         alt="Ruby T-Shirts"
         class="w-auto h-6 mb-2 dark:invert"
         loading="lazy"

--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -1,23 +1,18 @@
 ---
 layout: default
 ---
-{% if jekyll.environment == 'production' %}
-  {% capture image_url_root %}{{site.image_url }}/images/{% endcapture %}
-{% else %}
-  {% assign image_url_root = '/images/' %}
-{% endif %}
-
 {% if page.image %}
+  {%- capture hero_src -%}/images/{{ page.image.base }}.jpg{%- endcapture -%}
   <div class="relative w-screen max-w-7xl left-1/2 -translate-x-1/2 xl:rounded-lg xl:overflow-hidden">
     <picture>
       <img
         sizes="100vw"
         alt="{{ page.image.alt }}"
-        src="{{ image_url_root }}{{ page.image.base }}.jpg?blur=80&quality=40"
+        src="{% include cf_image.html src=hero_src blur=100 quality=40 %}"
         srcset="
-          {{ image_url_root }}{{ page.image.base }}.jpg?width=1024.jpg 1024w,
-          {{ image_url_root }}{{ page.image.base }}.jpg?width=1536 1536w,
-          {{ image_url_root }}{{ page.image.base }}.jpg?width=2048 2048w
+          {% include cf_image.html src=hero_src width=1024 %} 1024w,
+          {% include cf_image.html src=hero_src width=1536 %} 1536w,
+          {% include cf_image.html src=hero_src width=2048 %} 2048w
         "
         class="aspect-4/1 w-full object-cover"
         data-no-lazy

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,8 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "andycroll-com",
+  "compatibility_date": "2026-05-03",
+  "assets": {
+    "directory": "_site"
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `_includes/cf_image.html` and wraps every raster `<img>` (article hero, footer headshot, rubytshirts promo PNG) and every OG/Twitter/Schema.org image reference so production traffic goes through Cloudflare Image Transformations (`/cdn-cgi/image/format=auto,width=…/…`) while `jekyll serve` keeps using raw `/images/…` paths locally. Drops the `images.andycroll.com` BunnyCDN dependency: `image_url` removed from `_config.yml`, BunnyCDN entry removed from the `_headers` CSP and preconnect, duplicated `image_url_root` capture blocks deleted. Stray `?width=1024.jpg` typo in the article hero srcset fixed.
- Replaces the 6h Render-deploy-hook cron in `.github/workflows/deploy.yml` with a `workflow_dispatch` job that runs `bundle exec jekyll build` under `LANG=C.UTF-8` and then `cloudflare/wrangler-action@v3 deploy`. Adds `wrangler.jsonc` pointing the `andycroll-com` Worker at `_site` so wrangler skips its auto-detect rebuild path.
- `render.yaml`, `bin/render-build.sh`, and `netlify.toml` are intentionally left in place until DNS cuts over to Cloudflare; remove them in a follow-up.

## Prerequisites before running the deploy workflow

- Image Transformations enabled on the `andycroll.com` Cloudflare zone (paid feature).
- `andycroll-com` Worker created.
- Repo secrets `CLOUDFLARE_API_TOKEN` (Workers Scripts:Edit) and `CLOUDFLARE_ACCOUNT_ID`.

## Test plan

- [x] `JEKYLL_ENV=production bundle exec jekyll build` — `_site/` contains 1761 `/cdn-cgi/image/…` URLs and zero `images.andycroll.com` URLs in rendered output.
- [x] `bundle exec jekyll build` (dev) — raw `/images/…` paths preserved, zero `cdn-cgi` URLs in rendered output.
- [x] Spot-checked a 2018 article: hero `<picture>` srcset, footer headshot, `og:image`, `twitter:image`, and Schema.org BlogPosting/Person `image` all emit absolute `https://andycroll.com/cdn-cgi/image/…` URLs.
- [ ] After secrets are added: Actions → Deploy → Run workflow → main completes green and the Worker URL serves AVIF/WebP for raster images.