### PR TITLE
Fix invisible lazy-loaded images on production (CSP-blocked inline script)

### DIFF
--- a/_includes/javascripts.html
+++ b/_includes/javascripts.html
@@ -1,12 +1,3 @@
 <script src="https://cdn.usefathom.com/script.js" data-site="HUFOLVIQ" defer></script>
 <script src="https://instant.page/5.1.0" type="module" integrity="sha384-by67kQnR+pyfy8yWP4kPO12fHKRLHZPfEsiSXR8u2IKcTdxD805MGUXBzVPnkLHw" defer></script>
-<script>
-document.querySelectorAll('img[loading="lazy"]').forEach(function(img) {
-  if (img.complete) {
-    img.classList.add('loaded');
-  } else {
-    img.addEventListener('load', function() { img.classList.add('loaded'); }, { once: true });
-    img.addEventListener('error', function() { img.classList.add('loaded'); }, { once: true });
-  }
-});
-</script>
+<script src="/assets/js/lazy-images.js" defer></script>

--- a/assets/js/lazy-images.js
+++ b/assets/js/lazy-images.js
@@ -1,0 +1,8 @@
+document.querySelectorAll('img[loading="lazy"]').forEach(function (img) {
+  if (img.complete) {
+    img.classList.add('loaded');
+  } else {
+    img.addEventListener('load', function () { img.classList.add('loaded'); }, { once: true });
+    img.addEventListener('error', function () { img.classList.add('loaded'); }, { once: true });
+  }
+});


### PR DESCRIPTION
## Summary

After Cloudflare migration, every lazy-loaded raster image (footer headshot, promo PNGs, hero) renders at `opacity: 0` on production. Root cause chain:

1. `assets/css/custom.css:1-9` sets every `img[loading="lazy"]` to `opacity: 0` and only fades it in once the `.loaded` class is added.
2. `_includes/javascripts.html` had an **inline** `<script>` that adds `.loaded` on the image's `load` event.
3. The production CSP (`script-src 'self' *.andycroll.com instant.page cdn.usefathom.com`, no `'unsafe-inline'`) blocked that inline script.

The same CSP was set on Render but never enforced — Render doesn't process the `_headers` file (Netlify format). Cloudflare Workers static-assets *does* honor `_headers`, so the latent bug surfaced after DNS cutover.

Moved the script verbatim to `assets/js/lazy-images.js` and referenced it with `<script src="…" defer>`. `script-src 'self'` allows the external file — no CSP changes needed.

## Test plan

- [x] `JEKYLL_ENV=production bundle exec jekyll build` succeeds; `_site/assets/js/lazy-images.js` ships and `_site/index.html` references it.
- [ ] After deploy, open the homepage on andycroll.com → footer headshot, rubytshirts PNG, article hero all render (no `opacity: 0` stuck). Console shows no CSP violations.