### PR TITLE
Move email popover handlers to external JS for CSP

### DIFF
--- a/_includes/email_banner.html
+++ b/_includes/email_banner.html
@@ -4,7 +4,7 @@
     <p class="text-sm/6 text-stone-800 dark:text-stone-200">Ruby/Rails techniques, every two weeks</p>
     <button
       type="button"
-      onclick="document.getElementById('email-popover').showModal()"
+      data-email-popover-open
       class="rounded-md bg-red-700 px-3 py-1.5 text-sm font-semibold text-white hover:bg-red-800 cursor-pointer"
     >
       Subscribe

--- a/_includes/email_popover.html
+++ b/_includes/email_popover.html
@@ -2,7 +2,7 @@
   <div class="bg-white dark:bg-slate-800 rounded-xl shadow-2xl p-6 relative">
     <button
       type="button"
-      onclick="document.getElementById('email-popover').close()"
+      data-email-popover-close
       class="absolute top-3 right-3 text-stone-400 dark:text-stone-500 hover:text-stone-600 dark:hover:text-stone-300 cursor-pointer"
       aria-label="Close"
     >
@@ -51,9 +51,3 @@
     </form>
   </div>
 </dialog>
-
-<script>
-  document.getElementById('email-popover').addEventListener('click', function(e) {
-    if (e.target === this) this.close();
-  });
-</script>

--- a/_includes/javascripts.html
+++ b/_includes/javascripts.html
@@ -1,3 +1,4 @@
 <script src="https://cdn.usefathom.com/script.js" data-site="HUFOLVIQ" defer></script>
 <script src="https://instant.page/5.1.0" type="module" integrity="sha384-by67kQnR+pyfy8yWP4kPO12fHKRLHZPfEsiSXR8u2IKcTdxD805MGUXBzVPnkLHw" defer></script>
 <script src="/assets/js/lazy-images.js" defer></script>
+<script src="/assets/js/email-popover.js" defer></script>

--- a/assets/js/email-popover.js
+++ b/assets/js/email-popover.js
@@ -1,0 +1,14 @@
+const popover = document.getElementById('email-popover');
+if (popover) {
+  popover.addEventListener('click', function (e) {
+    if (e.target === popover) popover.close();
+  });
+
+  document.querySelectorAll('[data-email-popover-open]').forEach(function (btn) {
+    btn.addEventListener('click', function () { popover.showModal(); });
+  });
+
+  document.querySelectorAll('[data-email-popover-close]').forEach(function (btn) {
+    btn.addEventListener('click', function () { popover.close(); });
+  });
+}

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@ description: "CTO at CoverageBook, Rubyist, Conference Organizer, Speaker, Boots
       <p class="text-sm/6 text-stone-800 dark:text-stone-200">Ruby/Rails techniques, every two weeks</p>
       <button
         type="button"
-        onclick="document.getElementById('email-popover').showModal()"
+        data-email-popover-open
         class="flex-none rounded-md bg-red-700 px-3 py-1.5 text-sm font-semibold text-white hover:bg-red-800 cursor-pointer"
       >
         Subscribe

--- a/ruby/index.html
+++ b/ruby/index.html
@@ -25,7 +25,7 @@ redirect_from:
     <p class="text-sm/6 text-stone-800 dark:text-stone-200">Ruby/Rails techniques, every two weeks</p>
     <button
       type="button"
-      onclick="document.getElementById('email-popover').showModal()"
+      data-email-popover-open
       class="flex-none rounded-md bg-red-700 px-3 py-1.5 text-sm font-semibold text-white hover:bg-red-800 cursor-pointer"
     >
       Subscribe


### PR DESCRIPTION
## Summary

The site's CSP sets `script-src 'self'` with no `'unsafe-inline'`, which blocks both inline `<script>` blocks and inline `onclick` attributes. The email popover had one inline `<script>` (backdrop dismiss) and four inline `onclick` handlers (one close, three openers in `_includes/email_banner.html`, `index.html`, `ruby/index.html`) — all five would fail under the policy. This PR moves them into `assets/js/email-popover.js`, bound by `data-email-popover-open` / `data-email-popover-close` attributes so multiple opener buttons can coexist.

## Test plan

- [ ] `bundle exec jekyll serve` — DevTools console clean of CSP violations
- [ ] Bottom-banner Subscribe button opens the dialog on `/`, `/ruby/`, and a ruby category post
- [ ] Close (×) button closes the dialog
- [ ] Backdrop click closes the dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)