### PR TITLE
Serve Markdown for Agents via Accept-header negotiation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ ruby file: ".ruby-version"
 
 gem "jekyll"
 gem "nokogiri"
+gem "reverse_markdown"
 gem "jekyll-compose", group: [:jekyll_plugins]
 gem "jekyll-redirect-from", group: [:jekyll_plugins]
 gem "jekyll-sitemap", group: [:jekyll_plugins]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,8 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
+    reverse_markdown (3.0.2)
+      nokogiri
     rexml (3.4.4)
     rouge (4.6.1)
     safe_yaml (1.0.5)
@@ -113,6 +115,7 @@ DEPENDENCIES
   jekyll-tailwind
   logger
   nokogiri
+  reverse_markdown
   webrick
 
 RUBY VERSION

--- a/_config.yml
+++ b/_config.yml
@@ -10,7 +10,7 @@ description: "CTO at CoverageBook, Rubyist, Conference Organizer, Speaker, Boots
 base_url: ""
 
 include: ["_headers"]
-exclude: ["scripts", "bin"]
+exclude: ["scripts", "bin", "worker.js"]
 
 email: andy@goodscary.com
 

--- a/_plugins/markdown_twins.rb
+++ b/_plugins/markdown_twins.rb
@@ -1,0 +1,67 @@
+require "fileutils"
+require "nokogiri"
+require "reverse_markdown"
+
+module MarkdownTwins
+  FRONT_MATTER_PATTERN = /\A---\s*\n.*?\n---\s*\n/m
+  MARKDOWN_EXTS = %w[.md .markdown].freeze
+
+  module_function
+
+  def write(doc, site)
+    return unless twinable?(doc)
+    body = twin_body(doc)
+    return if body.nil? || body.empty?
+    output = compose(doc, site, body)
+    dest_dir = File.join(site.dest, doc.url)
+    FileUtils.mkdir_p(dest_dir)
+    File.write(File.join(dest_dir, "index.md"), output)
+  end
+
+  def twinable?(doc)
+    return false unless doc.url
+    doc.url.end_with?("/") || doc.url.end_with?(".html")
+  end
+
+  def twin_body(doc)
+    body =
+      if MARKDOWN_EXTS.include?(doc.extname.to_s.downcase)
+        File.read(doc.path, mode: "r:UTF-8").sub(FRONT_MATTER_PATTERN, "")
+      else
+        html_main_to_markdown(doc.output.to_s)
+      end
+    return nil if body.nil?
+    normalized = body.gsub("&nbsp;", " ").tr("\u00A0", " ").strip
+    normalized.empty? ? nil : normalized
+  end
+
+  def html_main_to_markdown(html)
+    return nil if html.empty?
+    node = Nokogiri::HTML(html).at_css("[role=main]")
+    return nil unless node
+    ReverseMarkdown.convert(node.inner_html, unknown_tags: :bypass)
+  end
+
+  def compose(doc, site, body)
+    title = doc.data["title"].to_s.strip
+    description = doc.data["description"].to_s.strip
+    canonical = "#{site.config["url"]}#{doc.url}"
+
+    parts = []
+    parts << "# #{title}" unless title.empty?
+    parts << "> #{description}" unless description.empty?
+    if doc.respond_to?(:date) && doc.date && doc.is_a?(Jekyll::Document)
+      parts << "*Published #{doc.date.strftime("%Y-%m-%d")} — <#{canonical}>*"
+    else
+      parts << "*<#{canonical}>*"
+    end
+    parts << "---"
+    parts << body
+    parts.join("\n\n") + "\n"
+  end
+end
+
+Jekyll::Hooks.register :site, :post_write do |site|
+  site.posts.docs.each { |doc| MarkdownTwins.write(doc, site) }
+  site.pages.each { |page| MarkdownTwins.write(page, site) }
+end

--- a/worker.js
+++ b/worker.js
@@ -1,0 +1,86 @@
+// Cloudflare Pages advanced-mode Worker.
+// Implements Markdown for Agents content negotiation: when a request sends
+// `Accept: text/markdown`, we serve the pre-generated `.md` twin produced at
+// Jekyll build time. Otherwise the request passes through to the static HTML.
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    const method = request.method;
+
+    if (method !== "GET" && method !== "HEAD") {
+      return env.ASSETS.fetch(request);
+    }
+
+    const accept = request.headers.get("accept") || "";
+    const wantsMarkdown = acceptsMarkdown(accept);
+
+    const pathLooksLikePage =
+      url.pathname.endsWith("/") ||
+      url.pathname.endsWith(".html") ||
+      !url.pathname.split("/").pop().includes(".");
+
+    if (wantsMarkdown && pathLooksLikePage) {
+      const mdPathname = url.pathname.replace(/\/?$/, "/") + "index.md";
+      const mdUrl = new URL(mdPathname, url);
+      const mdRequest = new Request(mdUrl.toString(), {
+        method: "GET",
+        headers: request.headers,
+      });
+      const mdResponse = await env.ASSETS.fetch(mdRequest);
+
+      if (mdResponse.ok) {
+        const body = await mdResponse.text();
+        const tokens = Math.ceil(body.length / 4);
+        const headers = new Headers({
+          "content-type": "text/markdown; charset=utf-8",
+          "x-markdown-tokens": String(tokens),
+          "cache-control":
+            mdResponse.headers.get("cache-control") || "public, max-age=300",
+          vary: "Accept",
+        });
+        return new Response(method === "HEAD" ? null : body, {
+          status: 200,
+          headers,
+        });
+      }
+      // No markdown twin at this URL — fall through to HTML.
+    }
+
+    const response = await env.ASSETS.fetch(request);
+    const contentType = response.headers.get("content-type") || "";
+    if (contentType.includes("text/html")) {
+      const headers = new Headers(response.headers);
+      appendVary(headers, "Accept");
+      return new Response(response.body, {
+        status: response.status,
+        statusText: response.statusText,
+        headers,
+      });
+    }
+    return response;
+  },
+};
+
+function acceptsMarkdown(accept) {
+  // Split on comma, trim, check each media range for text/markdown with non-zero q.
+  return accept.split(",").some((part) => {
+    const [mediaRange, ...params] = part.split(";").map((s) => s.trim());
+    if (!/^text\/markdown$/i.test(mediaRange)) return false;
+    const q = params
+      .map((p) => /^q=([\d.]+)$/i.exec(p))
+      .find(Boolean);
+    return !q || parseFloat(q[1]) > 0;
+  });
+}
+
+function appendVary(headers, value) {
+  const existing = headers.get("vary");
+  if (!existing) {
+    headers.set("vary", value);
+    return;
+  }
+  const tokens = existing.split(",").map((s) => s.trim().toLowerCase());
+  if (tokens.includes(value.toLowerCase())) return;
+  headers.set("vary", `${existing}, ${value}`);
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -2,7 +2,9 @@
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "andycroll-com",
   "compatibility_date": "2026-05-03",
+  "main": "worker.js",
   "assets": {
-    "directory": "_site"
+    "directory": "_site",
+    "binding": "ASSETS"
   }
 }


### PR DESCRIPTION
## Summary

Adds [Markdown for Agents](https://isitagentready.com/.well-known/agent-skills/markdown-negotiation/SKILL.md) content negotiation. Requests with `Accept: text/markdown` receive a Markdown twin of the page with `Content-Type: text/markdown; charset=utf-8` and an `x-markdown-tokens` estimate; everything else keeps getting HTML.

- `_plugins/markdown_twins.rb` writes an `index.md` next to every post and page output at build time. Posts and Markdown-source pages use the raw author source (no Liquid round-trip — closest to what was written); HTML-source pages have their `<div role="main">` extracted with Nokogiri and converted via `reverse_markdown`. Pages without a `[role="main"]` wrapper (e.g. `html-email.html`) are skipped. Non-breaking spaces are normalised to ASCII.
- `worker.js` is the static-assets Worker entry: it inspects `Accept`, serves the twin when Markdown is acceptable, and otherwise passes through to HTML with a `Vary: Accept`.
- `wrangler.jsonc` is updated to use `worker.js` as `main` and expose the `_site` assets via an `ASSETS` binding. `worker.js` is excluded from Jekyll output so it isn't also shipped as a public file.
- `reverse_markdown` is added to the Gemfile for the HTML→Markdown fallback.

## Test plan

- [ ] Trigger the `Deploy` workflow and confirm `wrangler deploy` uploads both the Worker and the static assets.
- [ ] `curl -sSI https://andycroll.com/ruby/<a-post>/` returns `content-type: text/html`.
- [ ] `curl -sSI -H 'Accept: text/markdown' https://andycroll.com/ruby/<a-post>/` returns `content-type: text/markdown; charset=utf-8` and an `x-markdown-tokens` header.
- [ ] `POST https://isitagentready.com/api/scan` with `andycroll.com` returns `checks.contentAccessibility.markdownNegotiation.status == "pass"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)