### PR TITLE
Add Superset workspace config

### DIFF
--- a/.superset/config.json
+++ b/.superset/config.json
@@ -1,0 +1,5 @@
+{
+  "setup": ["bundle install"],
+  "teardown": [],
+  "run": ["bundle exec jekyll serve --future --livereload"]
+}


### PR DESCRIPTION
## Summary
- Configures `.superset/config.json` so [Superset](https://docs.superset.sh/overview) workspaces (git-worktree-based) initialize cleanly for this Jekyll site.
- `setup`: `bundle install`
- `run`: `bundle exec jekyll serve --future --livereload` (matches the local dev flow in CLAUDE.md, plus `--future` so draft-dated posts preview)
- `teardown`: no-op (no shared services to stop)

Ruby version is picked up from `.ruby-version` (4.0.1) by whichever Ruby manager the workspace uses.

## Test plan
- [ ] Create a new Superset workspace from this branch; confirm `bundle install` runs to completion during setup.
- [ ] Click Run; confirm Jekyll boots, serves on the expected port, and live-reloads on edit.
- [ ] Delete the workspace; confirm teardown succeeds (no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)