### PR TITLE
Auto-deploy on green main and daily at 07:00 UTC

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,6 +2,13 @@ name: Deploy
 
 on:
   workflow_dispatch:
+  workflow_run:
+    workflows: ["Jekyll Tests"]
+    types: [completed]
+    branches: [main]
+  schedule:
+    # 07:00 UTC daily = 08:00 GMT / 07:00 BST.
+    - cron: '0 7 * * *'
 
 concurrency:
   group: deploy-production
@@ -9,10 +16,15 @@ concurrency:
 
 jobs:
   deploy:
+    if: >-
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
## Summary

Adds two new triggers to `deploy.yml` alongside the existing manual `workflow_dispatch`: a `workflow_run` that auto-deploys when `Jekyll Tests` passes on `main` (pinned to the CI commit SHA), and a daily cron at 07:00 UTC so future-dated posts ship on their publish date without a manual nudge. The deploy job's `if:` skips failed CI runs; the existing `deploy-production` concurrency group serialises overlaps.

Daylight savings note: 07:00 UTC is 08:00 in winter (GMT) and 07:00 in summer (BST) — accepted drift, no DST guard.

## Test plan

- [ ] Merge a no-op change to `main` and confirm `Deploy` auto-fires once `Jekyll Tests` goes green, against the same SHA.
- [ ] Manually run `Deploy` from the Actions tab — still works end-to-end.
- [ ] Tomorrow morning: confirm the scheduled run fires around 07:00 UTC and the live site reflects any newly-current future-dated posts.
- [ ] Open a PR with a broken build — confirm `Deploy` does **not** trigger from the PR's CI run.