### PR TITLE
Add bin/serve with per-worktree port

### DIFF
--- a/.superset/config.json
+++ b/.superset/config.json
@@ -1,5 +1,5 @@
 {
   "setup": ["bundle install"],
   "teardown": [],
-  "run": ["bundle exec jekyll serve --future --livereload"]
+  "run": ["bin/serve --future --livereload"]
 }

--- a/bin/serve
+++ b/bin/serve
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Run `jekyll serve` with a port derived from the current worktree path,
+# so multiple worktrees can run dev servers concurrently without collision.
+# Any extra arguments are passed through to `jekyll serve`.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+hash=$(printf '%s' "$PWD" | cksum | awk '{print $1}')
+port=$((4000 + hash % 100))
+livereload_port=$((35729 + hash % 100))
+
+echo "jekyll serve → http://127.0.0.1:${port} (worktree: ${PWD})"
+
+exec bundle exec jekyll serve \
+  --port "$port" \
+  --livereload-port "$livereload_port" \
+  "$@"


### PR DESCRIPTION
## Summary
- New `bin/serve` wrapper around `bundle exec jekyll serve`
- Derives a stable port in `4000–4099` (and matching livereload port offset from `35729`) from a `cksum` hash of the worktree's absolute path, so multiple worktrees can run dev servers side-by-side
- Forwards any extra arguments through to `jekyll serve`; user-supplied `--port` / `--livereload-port` will override the defaults (last flag wins per Jekyll's parser)

## Test plan
- [ ] `bin/serve --help` prints jekyll's help and the chosen port line
- [ ] `bin/serve` starts the dev server on the printed port
- [ ] Running `bin/serve` in a second worktree picks a different port
- [ ] `bin/serve --future` passes through and includes future-dated posts

🤖 Generated with [Claude Code](https://claude.com/claude-code)