### PR TITLE
Serve .md twin files as text/plain so browsers display rather than download

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -20,6 +20,22 @@ export default {
       url.pathname.endsWith(".html") ||
       !url.pathname.split("/").pop().includes(".");
 
+    // Direct .md URL — serve as plain text so browsers display rather than download
+    if (url.pathname.endsWith(".md")) {
+      const response = await env.ASSETS.fetch(request);
+      if (response.ok) {
+        const headers = new Headers(response.headers);
+        headers.set("content-type", "text/plain; charset=utf-8");
+        headers.delete("content-disposition");
+        return new Response(response.body, {
+          status: response.status,
+          statusText: response.statusText,
+          headers,
+        });
+      }
+      return response;
+    }
+
     if (wantsMarkdown && pathLooksLikePage) {
       const mdPathname = url.pathname.replace(/\/?$/, "/") + "index.md";
       const mdUrl = new URL(mdPathname, url);


### PR DESCRIPTION
The `MarkdownTwins` plugin generates `.md` versions of every page for LLM/agent consumption. When a browser directly requested one of these URLs (e.g. `/ruby/index.md`), Cloudflare Workers served it with a MIME type that triggered a file download instead of displaying the content.

The fix intercepts any request whose path ends in `.md` in `worker.js` and re-serves the asset with `Content-Type: text/plain; charset=utf-8`. This makes browsers render the content inline. The existing content-negotiation path — serving `text/markdown` when the client sends `Accept: text/markdown` — is unaffected, since that path only runs when `pathLooksLikePage` is true.

`text/markdown` isn't used for direct browser requests because Chrome, Firefox, and Safari all trigger a download for that MIME type.

---

[![Compound Engineering v2.54.1](https://img.shields.io/badge/Compound_Engineering-v2.54.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Sonnet 4.6 (1M context) via [Claude Code](https://claude.com/claude-code)